### PR TITLE
Feature/mambuv2 loan schedule

### DIFF
--- a/mambu_tests/tap_generators/test_repayments_generator.py
+++ b/mambu_tests/tap_generators/test_repayments_generator.py
@@ -10,4 +10,4 @@ def test_repayments_generator_endpoint_config_init():
 
     assert generator.endpoint_api_key_type is None
     assert generator.endpoint_parent_id == "TEST"
-    assert generator.endpoint_api_version == "v1"
+    assert generator.endpoint_api_version == "v2"

--- a/tap_mambu/helpers/schemas/loan_repayments.json
+++ b/tap_mambu/helpers/schemas/loan_repayments.json
@@ -39,7 +39,7 @@
     "expectedClosingBalance": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
       "format": "singer.decimal"
     },
@@ -60,28 +60,28 @@
             "due": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             },
             "expected": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             },
             "expectedUnapplied": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             },
             "paid": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             }
@@ -97,21 +97,21 @@
             "due": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             },
             "expected": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             },
             "paid": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             }
@@ -137,28 +137,28 @@
                   "due": {
                     "type": [
                       "null",
-                      "number"
+                      "string"
                     ],
                     "format": "singer.decimal"
                   },
                   "expected": {
                     "type": [
                       "null",
-                      "number"
+                      "string"
                     ],
                     "format": "singer.decimal"
                   },
                   "paid": {
                     "type": [
                       "null",
-                      "number"
+                      "string"
                     ],
                     "format": "singer.decimal"
                   },
                   "reduced": {
                     "type": [
                       "null",
-                      "number"
+                      "string"
                     ],
                     "format": "singer.decimal"
                   }
@@ -192,28 +192,28 @@
                   "due": {
                     "type": [
                       "null",
-                      "number"
+                      "string"
                     ],
                     "format": "singer.decimal"
                   },
                   "expected": {
                     "type": [
                       "null",
-                      "number"
+                      "string"
                     ],
                     "format": "singer.decimal"
                   },
                   "paid": {
                     "type": [
                       "null",
-                      "number"
+                      "string"
                     ],
                     "format": "singer.decimal"
                   },
                   "reduced": {
                     "type": [
                       "null",
-                      "number"
+                      "string"
                     ],
                     "format": "singer.decimal"
                   }
@@ -244,21 +244,21 @@
             "due": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             },
             "expected": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             },
             "paid": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             }
@@ -274,21 +274,21 @@
             "due": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             },
             "expected": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             },
             "paid": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             }
@@ -299,7 +299,7 @@
     "interestAccrued": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
       "format": "singer.decimal"
     },
@@ -316,7 +316,7 @@
       ],
       "format": "date-time"
     },
-    "number": {
+    "string": {
       "type": [
         "null",
         "string"
@@ -345,21 +345,21 @@
             "due": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             },
             "expected": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             },
             "paid": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             }
@@ -375,21 +375,21 @@
             "due": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             },
             "expected": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             },
             "paid": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             }
@@ -414,21 +414,21 @@
             "due": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             },
             "expected": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             },
             "paid": {
               "type": [
                 "null",
-                "number"
+                "string"
               ],
               "format": "singer.decimal"
             }

--- a/tap_mambu/helpers/schemas/loan_repayments.json
+++ b/tap_mambu/helpers/schemas/loan_repayments.json
@@ -2,303 +2,230 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "assigned_branch_key": {
-      "type": [
-        "null",
-        "string"
-      ]
+    "dueDate": {
+      "type": "string",
+      "format": "date-time"
     },
-    "assigned_centre_key": {
-      "type": [
-        "null",
-        "string"
-      ]
+    "encodedKey": {
+      "type": "string"
     },
-    "assigned_user_key": {
-      "type": [
-        "null",
-        "string"
-      ]
+    "expectedClosingBalance": {
+      "type": "number"
     },
-    "custom_settings": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "encoded_key": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "loan_transaction_key": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "source": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
+    "fee": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "due": {
+              "type": "number"
+            },
+            "expected": {
+              "type": "number"
+            },
+            "expectedUnapplied": {
+              "type": "number"
+            },
+            "paid": {
+              "type": "number"
             }
           }
         },
-        {
-          "type": "null"
+        "tax": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "due": {
+              "type": "number"
+            },
+            "expected": {
+              "type": "number"
+            },
+            "paid": {
+              "type": "number"
+            }
+          }
         }
-      ]
+      }
     },
-    "due_date": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "date-time"
-    },
-    "encoded_key": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "fees_applied_due": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "fees_due": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "fees_paid": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "fees_unapplied_due": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "funders_interest_due": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "index": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "interest_due": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "interest_paid": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "last_paid_date": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "date-time"
-    },
-    "last_penalty_applied_date": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "date-time"
-    },
-    "notes": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "organization_commission_due": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "parent_account_key": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "penalty_due": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "penalty_paid": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "principal_due": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "principal_paid": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "repaid_date": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "date-time"
-    },
-    "repayment_unapplied_fee_details": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
+    "feeDetails": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "amount": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "encoded_key": {
-                "type": [
-                  "null",
-                  "string"
-                ]
+              "due": {
+                "type": "number"
               },
-              "fee_due": {
-                "type": [
-                  "null",
-                  "string"
-                ],
-                "format": "singer.decimal"
+              "expected": {
+                "type": "number"
               },
-              "index_in_list": {
-                "type": [
-                  "null",
-                  "string"
-                ],
-                "format": "singer.decimal"
+              "paid": {
+                "type": "number"
               },
-              "predefined_fee_key": {
-                "type": [
-                  "null",
-                  "string"
-                ]
+              "reduced": {
+                "type": "number"
+              }
+            }
+          },
+          "encodedKey": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tax": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "due": {
+                "type": "number"
               },
-              "repayment_key": {
-                "type": [
-                  "null",
-                  "string"
-                ]
+              "expected": {
+                "type": "number"
               },
-              "tax_on_fee_due": {
-                "type": [
-                  "null",
-                  "string"
-                ],
-                "format": "singer.decimal"
+              "paid": {
+                "type": "number"
+              },
+              "reduced": {
+                "type": "number"
               }
             }
           }
-        },
-        {
-          "type": "null"
         }
-      ]
+      }
+    },
+    "interest": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "due": {
+              "type": "number"
+            },
+            "expected": {
+              "type": "number"
+            },
+            "paid": {
+              "type": "number"
+            }
+          }
+        },
+        "tax": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "due": {
+              "type": "number"
+            },
+            "expected": {
+              "type": "number"
+            },
+            "paid": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    },
+    "interestAccrued": {
+      "type": "number"
+    },
+    "isPaymentHoliday": {
+      "type": "boolean"
+    },
+    "lastPaidDate": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "number": {
+      "type": "string"
+    },
+    "parentAccountKey": {
+      "type": "string"
+    },
+    "penalty": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "due": {
+              "type": "number"
+            },
+            "expected": {
+              "type": "number"
+            },
+            "paid": {
+              "type": "number"
+            }
+          }
+        },
+        "tax": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "due": {
+              "type": "number"
+            },
+            "expected": {
+              "type": "number"
+            },
+            "paid": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    },
+    "principal": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "due": {
+              "type": "number"
+            },
+            "expected": {
+              "type": "number"
+            },
+            "paid": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    },
+    "repaidDate": {
+      "type": "string",
+      "format": "date-time"
     },
     "state": {
-      "type": [
-        "null",
-        "string"
-      ]
+      "type": "string"
     },
-    "tax_fees_due": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
+    "code": {
+      "type": "string"
     },
-    "tax_fees_paid": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "tax_interest_due": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "tax_interest_paid": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "tax_penalty_due": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "tax_penalty_paid": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
+    "currencyCode": {
+      "type": "string"
     }
   }
 }

--- a/tap_mambu/helpers/schemas/loan_repayments.json
+++ b/tap_mambu/helpers/schemas/loan_repayments.json
@@ -2,236 +2,453 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "currency": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "code": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "currencyCode": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
     "dueDate": {
-      "type": "string",
+      "type": [
+        "null",
+        "string"
+      ],
       "format": "date-time"
     },
     "encodedKey": {
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "expectedClosingBalance": {
-      "type": "number"
+      "type": [
+        "null",
+        "number"
+      ],
+      "format": "singer.decimal"
     },
     "fee": {
-      "type": "object",
+      "type": [
+        "null",
+        "object"
+      ],
       "additionalProperties": false,
       "properties": {
         "amount": {
-          "type": "object",
+          "type": [
+            "null",
+            "object"
+          ],
           "additionalProperties": false,
           "properties": {
             "due": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             },
             "expected": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             },
             "expectedUnapplied": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             },
             "paid": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             }
           }
         },
         "tax": {
-          "type": "object",
+          "type": [
+            "null",
+            "object"
+          ],
           "additionalProperties": false,
           "properties": {
             "due": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             },
             "expected": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             },
             "paid": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             }
           }
         }
       }
     },
     "feeDetails": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "amount": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "due": {
-                "type": "number"
+              "amount": {
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "due": {
+                    "type": [
+                      "null",
+                      "number"
+                    ],
+                    "format": "singer.decimal"
+                  },
+                  "expected": {
+                    "type": [
+                      "null",
+                      "number"
+                    ],
+                    "format": "singer.decimal"
+                  },
+                  "paid": {
+                    "type": [
+                      "null",
+                      "number"
+                    ],
+                    "format": "singer.decimal"
+                  },
+                  "reduced": {
+                    "type": [
+                      "null",
+                      "number"
+                    ],
+                    "format": "singer.decimal"
+                  }
+                }
               },
-              "expected": {
-                "type": "number"
+              "encodedKey": {
+                "type": [
+                  "null",
+                  "string"
+                ]
               },
-              "paid": {
-                "type": "number"
+              "id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
               },
-              "reduced": {
-                "type": "number"
-              }
-            }
-          },
-          "encodedKey": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "tax": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "due": {
-                "type": "number"
+              "name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
               },
-              "expected": {
-                "type": "number"
-              },
-              "paid": {
-                "type": "number"
-              },
-              "reduced": {
-                "type": "number"
+              "tax": {
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "due": {
+                    "type": [
+                      "null",
+                      "number"
+                    ],
+                    "format": "singer.decimal"
+                  },
+                  "expected": {
+                    "type": [
+                      "null",
+                      "number"
+                    ],
+                    "format": "singer.decimal"
+                  },
+                  "paid": {
+                    "type": [
+                      "null",
+                      "number"
+                    ],
+                    "format": "singer.decimal"
+                  },
+                  "reduced": {
+                    "type": [
+                      "null",
+                      "number"
+                    ],
+                    "format": "singer.decimal"
+                  }
+                }
               }
             }
           }
+        },
+        {
+          "type": "null"
         }
-      }
+      ]
     },
     "interest": {
-      "type": "object",
+      "type": [
+        "null",
+        "object"
+      ],
       "additionalProperties": false,
       "properties": {
         "amount": {
-          "type": "object",
+          "type": [
+            "null",
+            "object"
+          ],
           "additionalProperties": false,
           "properties": {
             "due": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             },
             "expected": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             },
             "paid": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             }
           }
         },
         "tax": {
-          "type": "object",
+          "type": [
+            "null",
+            "object"
+          ],
           "additionalProperties": false,
           "properties": {
             "due": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             },
             "expected": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             },
             "paid": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             }
           }
         }
       }
     },
     "interestAccrued": {
-      "type": "number"
+      "type": [
+        "null",
+        "number"
+      ],
+      "format": "singer.decimal"
     },
     "isPaymentHoliday": {
-      "type": "boolean"
+      "type": [
+        "null",
+        "boolean"
+      ]
     },
     "lastPaidDate": {
-      "type": "string",
+      "type": [
+        "null",
+        "string"
+      ],
       "format": "date-time"
     },
     "number": {
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "parentAccountKey": {
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ]
     },
     "penalty": {
-      "type": "object",
+      "type": [
+        "null",
+        "object"
+      ],
       "additionalProperties": false,
       "properties": {
         "amount": {
-          "type": "object",
+          "type": [
+            "null",
+            "object"
+          ],
           "additionalProperties": false,
           "properties": {
             "due": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             },
             "expected": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             },
             "paid": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             }
           }
         },
         "tax": {
-          "type": "object",
+          "type": [
+            "null",
+            "object"
+          ],
           "additionalProperties": false,
           "properties": {
             "due": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             },
             "expected": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             },
             "paid": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             }
           }
         }
       }
     },
     "principal": {
-      "type": "object",
+      "type": [
+        "null",
+        "object"
+      ],
       "additionalProperties": false,
       "properties": {
         "amount": {
-          "type": "object",
+          "type": [
+            "null",
+            "object"
+          ],
           "additionalProperties": false,
           "properties": {
             "due": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             },
             "expected": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             },
             "paid": {
-              "type": "number"
+              "type": [
+                "null",
+                "number"
+              ],
+              "format": "singer.decimal"
             }
           }
         }
       }
     },
     "repaidDate": {
-      "type": "string",
+      "type": [
+        "null",
+        "string"
+      ],
       "format": "date-time"
     },
     "state": {
-      "type": "string"
-    },
-    "currency": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "code": {
-          "type": "string"
-        },
-        "currencyCode": {
-          "type": "string"
-        }
-      }
+      "type": [
+        "null",
+        "string"
+      ],
+      "enum": ["PENDING", "PAID", "PARTIALLY_PAID", "UNPAID"]
     }
   }
 }

--- a/tap_mambu/helpers/schemas/loan_repayments.json
+++ b/tap_mambu/helpers/schemas/loan_repayments.json
@@ -221,11 +221,17 @@
     "state": {
       "type": "string"
     },
-    "code": {
-      "type": "string"
-    },
-    "currencyCode": {
-      "type": "string"
+    "currency": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "currencyCode": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/tap_mambu/tap_generators/loan_repayments_generator.py
+++ b/tap_mambu/tap_generators/loan_repayments_generator.py
@@ -1,11 +1,55 @@
+from gettext import install
+import sys
+from urllib import response
 from .child_generator import ChildGenerator
+from typing import List
+from singer import utils, get_logger
+
+from ..helpers import transform_json
+from ..helpers.hashable_dict import HashableDict
+
+LOGGER = get_logger()
 
 
 class LoanRepaymentsGenerator(ChildGenerator):
 
     def _init_endpoint_config(self):
         super(LoanRepaymentsGenerator, self)._init_endpoint_config()
-        self.endpoint_api_version = "v1"
+        self.endpoint_api_version = "v2"
         self.endpoint_api_method = "GET"
         # include parent id in endpoint path
-        self.endpoint_path = f"loans/{self.endpoint_parent_id}/repayments"
+        self.endpoint_path = f"loans/{self.endpoint_parent_id}/schedule"
+    
+    # Override the Generator method to retrieve schedule information from mambu apis
+    def fetch_batch(self):
+        endpoint_querystring = '&'.join([f'{key}={value}' for (key, value) in self.params.items()])
+
+        LOGGER.info(f'(generator) Stream {self.stream_name} - URL for {self.stream_name} ({self.endpoint_api_method}, '
+                    f'{self.endpoint_api_version}): {self.client.base_url}/{self.endpoint_path}?{endpoint_querystring}')
+        LOGGER.info(f'(generator) Stream {self.stream_name} - body = {self.endpoint_body}')
+
+        response = self.client.request(
+            method=self.endpoint_api_method,
+            path=self.endpoint_path,
+            version=self.endpoint_api_version,
+            apikey_type=self.endpoint_api_key_type,
+            params=endpoint_querystring,
+            endpoint=self.stream_name,
+            json=self.endpoint_body
+        )
+
+        response = self._format_response(response)
+
+        self.time_extracted = utils.now()
+        LOGGER.info(f'(generator) Stream {self.stream_name} - extracted records: {len(response)}')
+        return self.transform_batch(response)
+    
+    def _format_response(self, response):  
+        installments = []
+        for installment in response['installments']:
+            installment.update(response['currency'])
+            installments.append(installment)
+        
+        return installments
+        
+        

--- a/tap_mambu/tap_generators/loan_repayments_generator.py
+++ b/tap_mambu/tap_generators/loan_repayments_generator.py
@@ -15,7 +15,6 @@ class LoanRepaymentsGenerator(ChildGenerator):
 
     def _init_endpoint_config(self):
         super(LoanRepaymentsGenerator, self)._init_endpoint_config()
-        self.endpoint_api_version = "v2"
         self.endpoint_api_method = "GET"
         # include parent id in endpoint path
         self.endpoint_path = f"loans/{self.endpoint_parent_id}/schedule"

--- a/tap_mambu/tap_generators/loan_repayments_generator.py
+++ b/tap_mambu/tap_generators/loan_repayments_generator.py
@@ -1,11 +1,6 @@
-from gettext import install
-import sys
-from urllib import response
 from .child_generator import ChildGenerator
-from typing import List
-from singer import utils, get_logger
+from singer import get_logger
 
-from ..helpers import transform_json
 from ..helpers.hashable_dict import HashableDict
 
 LOGGER = get_logger()

--- a/tap_mambu/tap_generators/loan_repayments_generator.py
+++ b/tap_mambu/tap_generators/loan_repayments_generator.py
@@ -13,6 +13,11 @@ class LoanRepaymentsGenerator(ChildGenerator):
         self.endpoint_api_method = "GET"
         # include parent id in endpoint path
         self.endpoint_path = f"loans/{self.endpoint_parent_id}/schedule"
+        
+    def _init_params(self):
+        super(LoanRepaymentsGenerator, self)._init_params()
+        # set loan repayment request limit to zero since it returns all scheduled repayments on a loan
+        self.limit = 0
 
     def transform_batch(self, batch):
         batch_installments = batch['installments']

--- a/tap_mambu/tap_generators/loan_repayments_generator.py
+++ b/tap_mambu/tap_generators/loan_repayments_generator.py
@@ -19,37 +19,12 @@ class LoanRepaymentsGenerator(ChildGenerator):
         self.endpoint_api_method = "GET"
         # include parent id in endpoint path
         self.endpoint_path = f"loans/{self.endpoint_parent_id}/schedule"
-    
-    # Override the Generator method to retrieve schedule information from mambu apis
-    def fetch_batch(self):
-        endpoint_querystring = '&'.join([f'{key}={value}' for (key, value) in self.params.items()])
 
-        LOGGER.info(f'(generator) Stream {self.stream_name} - URL for {self.stream_name} ({self.endpoint_api_method}, '
-                    f'{self.endpoint_api_version}): {self.client.base_url}/{self.endpoint_path}?{endpoint_querystring}')
-        LOGGER.info(f'(generator) Stream {self.stream_name} - body = {self.endpoint_body}')
+    def transform_batch(self, batch):
+        batch_installments = batch['installments']
+        batch_currency = batch['currency']
 
-        response = self.client.request(
-            method=self.endpoint_api_method,
-            path=self.endpoint_path,
-            version=self.endpoint_api_version,
-            apikey_type=self.endpoint_api_key_type,
-            params=endpoint_querystring,
-            endpoint=self.stream_name,
-            json=self.endpoint_body
-        )
+        for installment in batch_installments: 
+            installment['currency'] = batch_currency
 
-        response = self._format_response(response)
-
-        self.time_extracted = utils.now()
-        LOGGER.info(f'(generator) Stream {self.stream_name} - extracted records: {len(response)}')
-        return self.transform_batch(response)
-    
-    def _format_response(self, response):  
-        installments = []
-        for installment in response['installments']:
-            installment.update(response['currency'])
-            installments.append(installment)
-        
-        return installments
-        
-        
+        return super(LoanRepaymentsGenerator, self).transform_batch(batch_installments)


### PR DESCRIPTION
# Description of change
Tap was still using version 1 of the mambu api for `loan_repayments` endpoint. Mambu changed the route and the schema

Mambu change documentation
- [Mambu revamp change guide](https://support.mambu.com/docs/revamp-of-mambu-apis)
- [Mambu updated api schema for loan repayments (now loan schedule)](https://api.mambu.com/#loan-accounts-getscheduleforloanaccount)

**Fix**

- Updated to conform to requirements mambu api v2

# Manual QA steps
 - Verified the fix with the tool singer-check-taps
 - Verified the results of executing with [target-csv](https://github.com/singer-io/target-csv)
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
